### PR TITLE
Error handle when command not found

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,9 +49,9 @@ Package doesn't provide keymap. If you want to use keybind, please setup `~/.ato
 
 * [ ] apply buffer (not file)
 * [ ] add spec
-* [ ] error handle
 
 ### Done
 
 * [x] rubocop path setting in config
 * [x] auto run
+* [x] error handle

--- a/lib/rubocop-auto-correct.coffee
+++ b/lib/rubocop-auto-correct.coffee
@@ -1,5 +1,6 @@
 {BufferedProcess, CompositeDisposable} = require 'atom'
 path = require 'path'
+which = require 'which'
 
 module.exports =
 class RubocopAutoCorrect
@@ -46,8 +47,19 @@ class RubocopAutoCorrect
         atom.notifications.addSuccess(output)
     stderr = (output) ->
       atom.notifications.addError(output)
-    process = new BufferedProcess({command, args, stdout, stderr})
-    process
+
+    which command, (err) ->
+      if (err)
+        return atom.notifications.addFatalError(
+          "Rubocop command is not found.",
+          { detail: '''
+          When you don't install rubocop yet, Run `gem install rubocop` first.\n
+          If you already installed rubocop, Please check package setting at `Rubocop Command Path`.
+          ''' }
+        )
+
+      process = new BufferedProcess({command, args, stdout, stderr})
+      process
 
   run: (editor) ->
     unless editor.getGrammar().scopeName.match("ruby")

--- a/package.json
+++ b/package.json
@@ -16,5 +16,7 @@
     "rubocop",
     "refactoring"
   ],
-  "dependencies": {}
+  "dependencies": {
+    "which": "^1.1.1"
+  }
 }


### PR DESCRIPTION
When rubcop command is not found, notice fatal error
