### PR TITLE
Allow the command configured for rubocop to have arguments.

### DIFF
--- a/lib/rubocop-auto-correct.coffee
+++ b/lib/rubocop-auto-correct.coffee
@@ -117,8 +117,9 @@ class RubocopAutoCorrect
             atom.notifications.addSuccess(message) if notification
 
   autoCorrectFile: (filePath)  ->
-    command = atom.config.get('rubocop-auto-correct.rubocopCommandPath')
-    args = ['-a', filePath]
+    command = atom.config.get('rubocop-auto-correct.rubocopCommandPath').split(/\s+/).filter((i) -> i).concat(['-a', filePath])
+    args = command[1..]
+    command = command[0]
     debug = atom.config.get('rubocop-auto-correct.debugMode')
     notification = atom.config.get('rubocop-auto-correct.notification')
     stdout = (output) ->


### PR DESCRIPTION
With this change, the rubocop command can be set to something like:

```
/Users/amuino/.rvm/bin/rvm-exec ruby-2.2.1@rubocop rubocop
```

The code was inspired by linter-rubocop, which allows the same config.
https://github.com/AtomLinter/linter-rubocop/blob/master/index.coffee#L22-L23
