### PR TITLE
Allow the command configured for rubocop to have arguments.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,12 @@
-## v1.1.0 (201-12-27)
+## v1.2.0 (2016-01-20)
+
+Features:
+
+- Improve `Rubocop Command Path` option
+  - Allow the command configure for Rubocop to have arguments.
+  - Thanks @amuino #21
+
+## v1.1.0 (2015-12-27)
 
 Features:
 

--- a/README.md
+++ b/README.md
@@ -68,11 +68,9 @@ You can enable/disable this option by `Rubocop Auto Correct: Toggle Notification
 
 ### Rubocop Command Path
 
-If you do not install rubocop yet, run `gem install rubocop` to install it!
+If you already installed rubocop, please check package setting at `Rubocop Command Path`. For example `~/.rbenv/shims/rubocop`.
 
-If you already installed rubocop, please check package setting at `Rubocop Command Path`.
-
-For example `~/.rbenv/shims/rubocop`.
+If you want to set arguments, please set arguments with command at here. For example `rubocop --format simple`
 
 - default value is `rubocop`
 

--- a/lib/rubocop-auto-correct.coffee
+++ b/lib/rubocop-auto-correct.coffee
@@ -117,8 +117,9 @@ class RubocopAutoCorrect
             atom.notifications.addSuccess(message) if notification
 
   autoCorrectFile: (filePath)  ->
-    command = atom.config.get('rubocop-auto-correct.rubocopCommandPath')
-    args = ['-a', filePath]
+    command = atom.config.get('rubocop-auto-correct.rubocopCommandPath').split(/\s+/).filter((i) -> i).concat(['-a', filePath])
+    args = command[1..]
+    command = command[0]
     debug = atom.config.get('rubocop-auto-correct.debugMode')
     notification = atom.config.get('rubocop-auto-correct.notification')
     stdout = (output) ->

--- a/lib/rubocop-auto-correct.coffee
+++ b/lib/rubocop-auto-correct.coffee
@@ -82,10 +82,13 @@ class RubocopAutoCorrect
       @autoCorrectBuffer(editor.getBuffer())
 
   autoCorrectBuffer: (buffer)  ->
-    command = atom.config.get('rubocop-auto-correct.rubocopCommandPath')
     tempFilePath = @makeTempFile("rubocop.rb")
     fs.writeFileSync(tempFilePath, buffer.getText())
-    args = ['-a', tempFilePath]
+    commandWithArgs = atom.config.get('rubocop-auto-correct.rubocopCommandPath')
+                                .split(/\s+/).filter((i) -> i)
+                                .concat(['-a', tempFilePath])
+    command = commandWithArgs[0]
+    args = commandWithArgs[1..]
     options = { encoding: 'utf-8', timeout: 5000 }
     notification = atom.config.get('rubocop-auto-correct.notification')
     debug = atom.config.get('rubocop-auto-correct.debugMode')
@@ -117,9 +120,11 @@ class RubocopAutoCorrect
             atom.notifications.addSuccess(message) if notification
 
   autoCorrectFile: (filePath)  ->
-    command = atom.config.get('rubocop-auto-correct.rubocopCommandPath').split(/\s+/).filter((i) -> i).concat(['-a', filePath])
-    args = command[1..]
-    command = command[0]
+    commandWithArgs = atom.config.get('rubocop-auto-correct.rubocopCommandPath')
+                                .split(/\s+/).filter((i) -> i)
+                                .concat(['-a', filePath])
+    command = commandWithArgs[0]
+    args = commandWithArgs[1..]
     debug = atom.config.get('rubocop-auto-correct.debugMode')
     notification = atom.config.get('rubocop-auto-correct.notification')
     stdout = (output) ->

--- a/spec/rubocop-auto-correct-spec.coffee
+++ b/spec/rubocop-auto-correct-spec.coffee
@@ -97,6 +97,33 @@ describe "RubocopAutoCorrect", ->
         runs ->
           expect(buffer.getText()).toBe "{ atom: 'A hackable text editor for the 21st Century' }\n"
 
+  describe "when command with arguments", ->
+    beforeEach ->
+      buffer.setText("{ :atom => 'A hackable text editor for the 21st Century' }\n")
+      atom.config.set('rubocop-auto-correct.rubocopCommandPath', 'rubocop --format simple')
+
+    describe "when correct buffer", ->
+      it "manually run", ->
+        atom.config.set('rubocop-auto-correct.correctFile', false)
+        atom.commands.dispatch workspaceElement, 'rubocop-auto-correct:current-file'
+        bufferChangedSpy = jasmine.createSpy()
+        buffer.onDidChange(bufferChangedSpy)
+        waitsFor ->
+          bufferChangedSpy.callCount > 0
+        runs ->
+          expect(buffer.getText()).toBe "{ atom: 'A hackable text editor for the 21st Century' }\n"
+
+    describe "when correct file", ->
+      it "manually run", ->
+        atom.config.set('rubocop-auto-correct.correctFile', true)
+        atom.commands.dispatch workspaceElement, 'rubocop-auto-correct:current-file'
+        bufferChangedSpy = jasmine.createSpy()
+        buffer.onDidChange(bufferChangedSpy)
+        waitsFor ->
+          bufferChangedSpy.callCount > 0
+        runs ->
+          expect(buffer.getText()).toBe "{ atom: 'A hackable text editor for the 21st Century' }\n"
+
   describe "when toggle config", ->
     beforeEach ->
       @rubocopAutoCorrect = new RubocopAutoCorrect


### PR DESCRIPTION
Improvement #21 
